### PR TITLE
Update examples to use TOML-array syntax for files

### DIFF
--- a/apache/httpd.manifest.template
+++ b/apache/httpd.manifest.template
@@ -34,18 +34,22 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sgx.thread_num = 32
 
-sgx.trusted_files.httpd = "file:{{ install_dir }}/bin/httpd"
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.conf = "file:{{ install_dir }}/conf"
-sgx.trusted_files.htdocs = "file:{{ install_dir }}/htdocs"
-sgx.trusted_files.modules = "file:{{ install_dir }}/modules"
+sgx.trusted_files = [
+  "file:{{ install_dir }}/bin/httpd",
+  "file:{{ gramine.runtimedir() }}",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:{{ install_dir }}/conf",
+  "file:{{ install_dir }}/htdocs",
+  "file:{{ install_dir }}/modules",
+]
 
-sgx.allowed_files.logs      = "file:{{ install_dir }}/logs"
-sgx.allowed_files.nsswitch  = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers    = "file:/etc/ethers"
-sgx.allowed_files.hosts     = "file:/etc/hosts"
-sgx.allowed_files.group     = "file:/etc/group"
-sgx.allowed_files.passwd    = "file:/etc/passwd"
-sgx.allowed_files.gaiconf   = "file:/etc/gai.conf"
+sgx.allowed_files = [
+  "file:{{ install_dir }}/logs",
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+]

--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -32,16 +32,20 @@ fs.mount.curl.uri = "file:{{ curl_dir }}"
 sgx.enclave_size = "256M"
 sgx.thread_num = 4
 
-sgx.trusted_files.curl = "file:{{ curl_dir }}/curl"
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
+sgx.trusted_files = [
+  "file:{{ curl_dir }}/curl",
+  "file:{{ gramine.runtimedir() }}",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+]
 
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.hostconf = "file:/etc/host.conf"
-sgx.allowed_files.resolvconf = "file:/etc/resolv.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
+sgx.allowed_files = [
+  "file:/etc/nsswitch.conf",
+  "file:/etc/host.conf",
+  "file:/etc/resolv.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/gai.conf",
+]

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -29,18 +29,20 @@ fs.mount.tmp.uri = "file:/tmp"
 sgx.enclave_size = "1G"
 sgx.nonpie_binary = true
 
-sgx.trusted_files.gcc = "file:/usr/bin/gcc"
-sgx.trusted_files.as = "file:/usr/bin/as"
-sgx.trusted_files.ld_ = "file:/usr/bin/ld"
+sgx.trusted_files = [
+  "file:/usr/bin/gcc",
+  "file:/usr/bin/as",
+  "file:/usr/bin/ld",
+  "file:{{ gramine.runtimedir() }}",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:{{ gcc_lib_path }}/{{ gcc_major_version }}/",
+  "file:/usr/lib/debug/usr/{{ arch_libdir }}",
+]
 
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.gcc_data = "file:{{ gcc_lib_path }}/{{ gcc_major_version }}/"
-sgx.trusted_files.hostdebug = "file:/usr/lib/debug/usr/{{ arch_libdir }}"
-
-sgx.allowed_files.tmp = "file:/tmp"
-sgx.allowed_files.test_files = "file:test_files"
-sgx.allowed_files.aout = "file:a.out"
-
-sgx.allowed_files.inc = "file:/usr/include"
+sgx.allowed_files = [
+  "file:/tmp",
+  "file:test_files",
+  "file:a.out",
+  "file:/usr/include",
+]

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -33,8 +33,10 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "2G"
 sgx.thread_num = 32
 
-sgx.trusted_files.nodejs = "file:{{ nodejs_dir }}/nodejs"
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.javascript = "file:helloworld.js"
+sgx.trusted_files = [
+  "file:{{ nodejs_dir }}/nodejs",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:helloworld.js",
+]

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -24,12 +24,14 @@ sgx.enclave_size = "16G"
 # SGX needs minimum 64 threads for loading OpenJDK runtime.
 sgx.thread_num = 64
 
-sgx.trusted_files.java = "file:{{ entrypoint }}"
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.jdk_libs = "file:/usr/lib/jvm/java-11-openjdk-amd64/lib"
-sgx.trusted_files.jdk_security = "file:/usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security"
-sgx.trusted_files.atk_wrapper = "file:/usr/share/java/java-atk-wrapper.jar"
-sgx.trusted_files.hello = "file:MultiThreadMain.class"
-sgx.trusted_files.sync_counter = "file:SyncedCounter.class"
+sgx.trusted_files = [
+  "file:{{ entrypoint }}",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:/usr/lib/jvm/java-11-openjdk-amd64/lib",
+  "file:/usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security",
+  "file:/usr/share/java/java-atk-wrapper.jar",
+  "file:MultiThreadMain.class",
+  "file:SyncedCounter.class",
+]

--- a/openvino/object_detection_sample_ssd.manifest.template
+++ b/openvino/object_detection_sample_ssd.manifest.template
@@ -31,18 +31,22 @@ fs.mount.cwd.uri = "file:{{ openvino_dir }}"
 sgx.enclave_size = "2G"
 sgx.thread_num = 16
 
-sgx.trusted_files.object_detection_sample_ssd = "file:{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/object_detection_sample_ssd"
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.openvino_libs = "file:{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/"
-sgx.trusted_files.opencv_libs = "file:{{ openvino_dir }}/inference-engine/temp/"
-sgx.trusted_files.modelxml = "file:{{ model_dir }}/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.xml"
-sgx.trusted_files.modelbin = "file:{{ model_dir }}/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.bin"
+sgx.trusted_files = [
+  "file:{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/object_detection_sample_ssd",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/",
+  "file:{{ openvino_dir }}/inference-engine/temp/",
+  "file:{{ model_dir }}/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.xml",
+  "file:{{ model_dir }}/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.bin",
+]
 
-sgx.allowed_files.imagesdir = "file:images"
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.ethers = "file:/etc/ethers"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
+sgx.allowed_files = [
+  "file:images",
+  "file:/etc/nsswitch.conf",
+  "file:/etc/ethers",
+  "file:/etc/hosts",
+  "file:/etc/group",
+  "file:/etc/passwd",
+]

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -45,40 +45,42 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
 sgx.thread_num = 256
 
-sgx.trusted_files.python = "file:{{ entrypoint }}"
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.python_dir = "file:{{ python.stdlib }}/"
-sgx.trusted_files.dist = "file:{{ python.distlib }}/"
-sgx.trusted_files.home_lib = "file:{{ env.HOME }}/.local/lib/"
-sgx.trusted_files.python_local_lib = "file:{{
-    python.get_path('stdlib', vars={'installed_base': '/usr/local'}) }}"
+sgx.trusted_files = [
+  "file:{{ entrypoint }}",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:{{ python.stdlib }}/",
+  "file:{{ python.distlib }}/",
+  "file:{{ env.HOME }}/.local/lib/",
+  "file:{{ python.get_path('stdlib', vars={'installed_base': '/usr/local'}) }}",
 
-sgx.trusted_files.script = "file:pytorchexample.py"
-sgx.trusted_files.classes = "file:classes.txt"
-sgx.trusted_files.image = "file:input.jpg"
+  "file:pytorchexample.py",
+  "file:classes.txt",
+  "file:input.jpg",
 
-# File containing the pre-trained model
-# Uncomment lines below if you want to use torchvision.model.alexnet(pretrained=True)
-# sgx.trusted_files.torch = "file:{{ env.HOME }}/.cache/torch/checkpoints/alexnet-owt-4df8aa71.pth"
+  # Pre-trained model saved as a file
+  "file:alexnet-pretrained.pt",
 
-# Pre-trained model saved as a file
-sgx.trusted_files.model = "file:alexnet-pretrained.pt"
+  # Uncomment line below if you want to use torchvision.model.alexnet(pretrained=True)
+  # "file:{{ env.HOME }}/.cache/torch/checkpoints/alexnet-owt-4df8aa71.pth",
+]
 
-sgx.allowed_files.tmp = "file:/tmp"
-sgx.allowed_files.aptconfd = "file:/etc/apt/apt.conf.d"
-sgx.allowed_files.aptconf = "file:/etc/apt/apt.conf"
-sgx.allowed_files.apport = "file:/etc/default/apport"
-sgx.allowed_files.nsswitch = "file:/etc/nsswitch.conf"
-sgx.allowed_files.group = "file:/etc/group"
-sgx.allowed_files.passwd = "file:/etc/passwd"
-sgx.allowed_files.hostconf = "file:/etc/host.conf"
-sgx.allowed_files.hosts = "file:/etc/hosts"
-sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
-sgx.allowed_files.resolv = "file:/etc/resolv.conf"
-sgx.allowed_files.fstab = "file:/etc/fstab"
-sgx.allowed_files.result = "file:result.txt"
+sgx.allowed_files = [
+  "file:/tmp",
+  "file:/etc/apt/apt.conf.d",
+  "file:/etc/apt/apt.conf",
+  "file:/etc/default/apport",
+  "file:/etc/nsswitch.conf",
+  "file:/etc/group",
+  "file:/etc/passwd",
+  "file:/etc/host.conf",
+  "file:/etc/hosts",
+  "file:/etc/gai.conf",
+  "file:/etc/resolv.conf",
+  "file:/etc/fstab",
+  "file:result.txt",
+]
 
 # Gramine optionally provides patched OpenMP runtime library that runs faster
 # inside SGX enclaves (execute `make -C LibOS gcc` to generate it). Uncomment

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -45,16 +45,20 @@ sys.stack.size = "8M"
 sgx.enclave_size = "1G"
 sgx.thread_num = 4
 
-sgx.trusted_files.r = "file:{{ r_exec }}"
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.stats_lib = "file:{{ r_home }}/"
-sgx.trusted_files.scripts = "file:scripts/"
+sgx.trusted_files = [
+  "file:{{ r_exec }}",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:{{ r_home }}/",
+  "file:scripts/",
 
-# R uses shell to delete files, so we need to allow /bin/sh and /bin/rm to be accessed.
-# strace snippet: execve("/bin/sh", ["sh", "-c", "rm -rf /tmp/RtmpEiedDF"], [/* 41 vars */])
-sgx.trusted_files.rm = "file:/bin/rm"
-sgx.trusted_files.sh = "file:/bin/sh"
+  # R uses shell to delete files, so we need to allow /bin/sh and /bin/rm to be accessed.
+  # strace snippet: execve("/bin/sh", ["sh", "-c", "rm -rf /tmp/RtmpEiedDF"], [/* 41 vars */])
+  "file:/bin/rm",
+  "file:/bin/sh",
+]
 
-sgx.allowed_files.tmp = "file:/tmp"
+sgx.allowed_files = [
+  "file:/tmp",
+]

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -25,13 +25,16 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sgx.thread_num = 16
 
-sgx.trusted_files.label_image = "file:label_image"
-sgx.trusted_files.runtime = "file:{{ gramine.runtimedir() }}/"
-sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
-sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
-sgx.trusted_files.libtensorflowframework = "file:libtensorflow_framework.so"
+sgx.trusted_files = [
+  "file:label_image",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:libtensorflow_framework.so",
+  "file:inception_v3.tflite",
+  "file:labels.txt",
+]
 
-sgx.trusted_files.model = "file:inception_v3.tflite"
-sgx.trusted_files.labels = "file:labels.txt"
-
-sgx.allowed_files.image = "file:image.bmp"
+sgx.allowed_files = [
+  "file:image.bmp",
+]


### PR DESCRIPTION
All example manifests now use the TOML-array syntax for `sgx.trusted_files`, `sgx.allowed_files` and `sgx.protected_files`.

This PR is a counterpart to core-repo https://github.com/gramineproject/gramine/pull/66

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/5)
<!-- Reviewable:end -->
