### PR TITLE
Update examples to use `loader.entrypoint` instead of `loader.preload`

### DIFF
--- a/apache/httpd.manifest.template
+++ b/apache/httpd.manifest.template
@@ -1,7 +1,8 @@
 # Apache manifest example
 
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ install_dir }}/bin/httpd"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/{{ arch_libdir }}"
@@ -35,13 +36,14 @@ sgx.enclave_size = "512M"
 sgx.thread_num = 32
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:{{ install_dir }}/bin/httpd",
-  "file:{{ gramine.runtimedir() }}",
+  "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
-  "file:{{ install_dir }}/conf",
-  "file:{{ install_dir }}/htdocs",
-  "file:{{ install_dir }}/modules",
+  "file:{{ install_dir }}/conf/",
+  "file:{{ install_dir }}/htdocs/",
+  "file:{{ install_dir }}/modules/",
 ]
 
 sgx.allowed_files = [

--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -1,7 +1,8 @@
 # Curl manifest file example
 
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ curl_dir }}/curl"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -33,8 +34,9 @@ sgx.enclave_size = "256M"
 sgx.thread_num = 4
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:{{ curl_dir }}/curl",
-  "file:{{ gramine.runtimedir() }}",
+  "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
 ]

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -1,8 +1,9 @@
 # This is a general manifest template for running GCC and its utility programs,
 # including as, cc1, collect2, ld.
 
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/usr/bin/gcc"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/{{ arch_libdir }}"
@@ -30,14 +31,15 @@ sgx.enclave_size = "1G"
 sgx.nonpie_binary = true
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:/usr/bin/gcc",
   "file:/usr/bin/as",
   "file:/usr/bin/ld",
-  "file:{{ gramine.runtimedir() }}",
+  "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
   "file:{{ gcc_lib_path }}/{{ gcc_major_version }}/",
-  "file:/usr/lib/debug/usr/{{ arch_libdir }}",
+  "file:/usr/lib/debug/usr/{{ arch_libdir }}/",
 ]
 
 sgx.allowed_files = [

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -1,7 +1,8 @@
 # Node.js manifest file example
 
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ nodejs_dir }}/nodejs"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -34,6 +35,7 @@ sgx.enclave_size = "2G"
 sgx.thread_num = 32
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:{{ nodejs_dir }}/nodejs",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -1,5 +1,6 @@
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
-loader.preload = "file:{{ gramine.libos }}"
+
 loader.log_level = "{{ log_level }}"
 
 loader.insecure__use_cmdline_argv = true
@@ -25,11 +26,12 @@ sgx.enclave_size = "16G"
 sgx.thread_num = 64
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:{{ entrypoint }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
-  "file:/usr/lib/jvm/java-11-openjdk-amd64/lib",
+  "file:/usr/lib/jvm/java-11-openjdk-amd64/lib"/,
   "file:/usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security",
   "file:/usr/share/java/java-atk-wrapper.jar",
   "file:MultiThreadMain.class",

--- a/openvino/object_detection_sample_ssd.manifest.template
+++ b/openvino/object_detection_sample_ssd.manifest.template
@@ -1,7 +1,8 @@
 # OpenVINO (object_detection_sample_ssd) manifest example
 
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/object_detection_sample_ssd"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ openvino_dir }}/inference-engine/temp/tbb/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -32,6 +33,7 @@ sgx.enclave_size = "2G"
 sgx.thread_num = 16
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/object_detection_sample_ssd",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -1,7 +1,8 @@
 # PyTorch manifest template
 
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/usr/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
@@ -46,6 +47,7 @@ sgx.enclave_size = "16G"
 sgx.thread_num = 256
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:{{ entrypoint }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
@@ -53,7 +55,7 @@ sgx.trusted_files = [
   "file:{{ python.stdlib }}/",
   "file:{{ python.distlib }}/",
   "file:{{ env.HOME }}/.local/lib/",
-  "file:{{ python.get_path('stdlib', vars={'installed_base': '/usr/local'}) }}",
+  "file:{{ python.get_path('stdlib', vars={'installed_base': '/usr/local'}) }}/",
 
   "file:pytorchexample.py",
   "file:classes.txt",

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -1,7 +1,8 @@
 # R manifest example
 
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ r_exec }}"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "{{ r_home }}/lib:/lib:{{ arch_libdir }}:/usr/lib:/usr/{{ arch_libdir }}"
@@ -46,6 +47,7 @@ sgx.enclave_size = "1G"
 sgx.thread_num = 4
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:{{ r_exec }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -1,7 +1,8 @@
 # TensorFlow Lite example
 
-loader.preload = "file:{{ gramine.libos }}"
+loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "label_image"
+
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}:."
@@ -26,6 +27,7 @@ sgx.enclave_size = "512M"
 sgx.thread_num = 16
 
 sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
   "file:label_image",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",


### PR DESCRIPTION
Also, a small bug is fixed in `sgx.trusted_files` for several examples: some directories didn't have the trailing `/` symbol.

Must be merged after https://github.com/gramineproject/gramine/pull/194.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/8)
<!-- Reviewable:end -->
