### PR TITLE
Fix typo in the manifest of OpenJDK (Java) example

### DIFF
--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -31,7 +31,7 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
-  "file:/usr/lib/jvm/java-11-openjdk-amd64/lib"/,
+  "file:/usr/lib/jvm/java-11-openjdk-amd64/lib/",
   "file:/usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security",
   "file:/usr/share/java/java-atk-wrapper.jar",
   "file:MultiThreadMain.class",


### PR DESCRIPTION
Fixes #9. Kudos to @zhwb who found it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/10)
<!-- Reviewable:end -->
