### PR TITLE
Update examples to use `loader.preload` for backwards compatibility

### DIFF
--- a/apache/httpd.manifest.template
+++ b/apache/httpd.manifest.template
@@ -1,5 +1,7 @@
 # Apache manifest example
 
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ install_dir }}/bin/httpd"
 

--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -1,5 +1,7 @@
 # Curl manifest file example
 
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ curl_dir }}/curl"
 

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -1,6 +1,8 @@
 # This is a general manifest template for running GCC and its utility programs,
 # including as, cc1, collect2, ld.
 
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/usr/bin/gcc"
 

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -1,5 +1,7 @@
 # Node.js manifest file example
 
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ nodejs_dir }}/nodejs"
 

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -1,3 +1,5 @@
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 

--- a/openvino/object_detection_sample_ssd.manifest.template
+++ b/openvino/object_detection_sample_ssd.manifest.template
@@ -1,5 +1,7 @@
 # OpenVINO (object_detection_sample_ssd) manifest example
 
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/object_detection_sample_ssd"
 

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -1,5 +1,7 @@
 # PyTorch manifest template
 
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -1,5 +1,7 @@
 # R manifest example
 
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ r_exec }}"
 

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -1,5 +1,7 @@
 # TensorFlow Lite example
 
+loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "label_image"
 


### PR DESCRIPTION
Commit "Update examples to use `loader.entrypoint` instead of `loader.preload`" removed the `loader.preload` manifest option from all examples' manifests. However, Gramine v1.0 doesn't recognize the new `loader.entrypoint` option and thus fails. (See PR https://github.com/gramineproject/examples/pull/8)

This PR fixes that.

Fixes #11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/12)
<!-- Reviewable:end -->
