### PR TITLE
Drop loader.preload backward-compatibility entries in manifests

### DIFF
--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -1,7 +1,5 @@
 # Curl manifest file example
 
-loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ curl_dir }}/curl"
 

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -1,8 +1,6 @@
 # This is a general manifest template for running GCC and its utility programs,
 # including as, cc1, collect2, ld.
 
-loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/usr/bin/gcc"
 

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -1,7 +1,5 @@
 # Node.js manifest file example
 
-loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ nodejs_dir }}/nodejs"
 

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -1,5 +1,3 @@
-loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 

--- a/openvino/object_detection_sample_ssd.manifest.template
+++ b/openvino/object_detection_sample_ssd.manifest.template
@@ -1,7 +1,5 @@
 # OpenVINO (object_detection_sample_ssd) manifest example
 
-loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/object_detection_sample_ssd"
 

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -1,7 +1,5 @@
 # PyTorch manifest template
 
-loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -1,7 +1,5 @@
 # R manifest example
 
-loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ r_exec }}"
 

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -1,7 +1,5 @@
 # TensorFlow Lite example
 
-loader.preload = "file:{{ gramine.libos }}"  # for compatibility with v1.0
-
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "label_image"
 


### PR DESCRIPTION
It was already long-deprecated.