### PR TITLE
Add missing `wait_for_server` utility

### DIFF
--- a/common_tools/wait_for_server
+++ b/common_tools/wait_for_server
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+
+usage() {
+    echo "Usage: wait_for_server TIMEOUT IP PORT"
+    exit 1
+}
+
+if [ $# -ne 3 ]; then
+    usage
+fi
+
+exec timeout $1 bash -c "while ! nc -z -w1 $2 $3; do sleep 1; done"

--- a/curl/Makefile
+++ b/curl/Makefile
@@ -47,7 +47,7 @@ endif
 .PHONY: check
 check: all
 	(cd test-docroot; exec python3 -m http.server -b 127.0.0.1 19111) & httpd_pid=$$!; \
-	../../Scripts/wait_for_server 5 127.0.0.1 19111; \
+	../common_tools/wait_for_server 5 127.0.0.1 19111; \
 	$(GRAMINE) ./curl http://127.0.0.1:19111/ > OUTPUT; rc=$$?; \
 	kill $$httpd_pid; exit $$rc
 


### PR DESCRIPTION
This utility is currently used only by Curl, but may be used by other client-server applications in the future.

We forgot to change the Curl Makefile while moving Curl away from the core Gramine repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/21)
<!-- Reviewable:end -->
