### PR TITLE
Remove java-atk-wrapper from openjdk example

### DIFF
--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -33,7 +33,6 @@ sgx.trusted_files = [
   "file:/usr/{{ arch_libdir }}/",
   "file:/usr/lib/jvm/java-11-openjdk-amd64/lib/",
   "file:/usr/lib/jvm/java-11-openjdk-amd64/conf/security/java.security",
-  "file:/usr/share/java/java-atk-wrapper.jar",
   "file:MultiThreadMain.class",
   "file:SyncedCounter.class",
 ]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/23)
<!-- Reviewable:end -->
