### PR TITLE
Setting number of threads for Pytorch

### DIFF
--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -7,6 +7,10 @@ loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/usr/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
+# Restrict the maximum number of threads to prevent insufficient memory
+# issue, observed on CentOS/RHEL.
+loader.env.OMP_NUM_THREADS = "8"
+
 loader.insecure__use_cmdline_argv = true
 loader.insecure__use_host_env = true
 


### PR DESCRIPTION
In this commit, the number of threads is set appropriately so as to
prevent running out of memory for Gramine-SGX. This is required
after sysfs topology was enabled by default in the master.

Signed-off-by: Aniket Borkar <aniketx.borkar@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/24)
<!-- Reviewable:end -->
