### PR TITLE
Increase R enclave size to 2G

### DIFF
--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -43,7 +43,7 @@ fs.mount.bin.uri = "file:/bin"
 
 sgx.nonpie_binary = true
 sys.stack.size = "8M"
-sgx.enclave_size = "1G"
+sgx.enclave_size = "2G"
 sgx.thread_num = 4
 
 sgx.trusted_files = [


### PR DESCRIPTION
SGX Enclave size is not sufficient for CentOS machine,
hence increasing the enclave size to 2G

Signed-off-by: anjalirai-intel <anjali.rai@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/25)
<!-- Reviewable:end -->
