### PR TITLE
Apply Make workaround for grouped targets to all examples

### DIFF
--- a/curl/Makefile
+++ b/curl/Makefile
@@ -25,15 +25,17 @@ curl.manifest: curl.manifest.template
 		-Dcurl_dir=$(CURL_DIR) \
 		$< >$@
 
-curl.manifest.sgx: curl.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
-	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
-		--manifest curl.manifest \
-		--output $@
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+curl.manifest.sgx curl.sig: sgx_sign
+	@:
 
-curl.sig: curl.manifest.sgx
+.INTERMEDIATE: sgx_sign
+sgx_sign: curl.manifest
+	gramine-sgx-sign \
+		--manifest $< \
+		--output $<.sgx
 
 curl.token: curl.sig
 	gramine-sgx-get-token --output $@ --sig $^

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -31,7 +31,7 @@ ifeq ($(SGX),1)
 all: gcc.manifest.sgx gcc.sig gcc.token
 endif
 
-%.manifest: %.manifest.template
+gcc.manifest: gcc.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
@@ -40,20 +40,18 @@ endif
 		$< >$@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# we need to hack around.
-gcc.sig gcc.manifest.sgx: sgx_outputs
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+gcc.manifest.sgx gcc.sig: sgx_sign
 	@:
 
-.INTERMEDIATE: sgx_outputs
-sgx_outputs: gcc.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
+.INTERMEDIATE: sgx_sign
+sgx_sign: gcc.manifest
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
-		--manifest gcc.manifest \
-		--output gcc.manifest.sgx
+		--manifest $< \
+		--output $<.sgx
 
-%.token: %.sig
+gcc.token: gcc.sig
 	gramine-sgx-get-token --output $@ --sig $<
 
 test_files/bzip2.c:

--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -24,15 +24,17 @@ nodejs.manifest: nodejs.manifest.template
 		-Dnodejs_dir=$(NODEJS_DIR) \
 		$< >$@
 
-nodejs.manifest.sgx: nodejs.manifest helloworld.js
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
-	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
-		--manifest $< \
-		--output $@
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+nodejs.manifest.sgx nodejs.sig: sgx_sign
+	@:
 
-nodejs.sig: nodejs.manifest.sgx
+.INTERMEDIATE: sgx_sign
+sgx_sign: nodejs.manifest helloworld.js
+	gramine-sgx-sign \
+		--manifest $< \
+		--output $<.sgx
 
 nodejs.token: nodejs.sig
 	gramine-sgx-get-token --output $@ --sig $<

--- a/openjdk/Makefile
+++ b/openjdk/Makefile
@@ -29,15 +29,17 @@ java.manifest: java.manifest.template
 		-Dentrypoint=$(realpath $(shell sh -c "command -v java")) \
 		$< >$@
 
-java.manifest.sgx: java.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-		{ echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
-	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
-		--manifest $< \
-		--output $@
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+java.manifest.sgx java.sig: sgx_sign
+	@:
 
-java.sig: java.manifest.sgx
+.INTERMEDIATE: sgx_sign
+sgx_sign: java.manifest
+	gramine-sgx-sign \
+		--manifest $< \
+		--output $<.sgx
 
 java.token: java.sig
 	gramine-sgx-get-token --output $@ --sig $<

--- a/openvino/Makefile
+++ b/openvino/Makefile
@@ -83,18 +83,20 @@ benchmark_app.manifest: benchmark_app.manifest.template
 		-Dinference_engine_cpp_samples_build=$(abspath $(INFERENCE_ENGINE_CPP_SAMPLES_BUILD)) \
 		$< > $@
 
-benchmark_app.manifest.sgx: benchmark_app.manifest | benchmark_app
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
-	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
-		--manifest $< \
-		--output $@
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+benchmark_app.manifest.sgx benchmark_app.sig: sgx_sign
+	@:
 
-benchmark_app.sig: benchmark_app.manifest.sgx
+.INTERMEDIATE: sgx_sign
+sgx_sign: benchmark_app.manifest | benchmark_app
+	gramine-sgx-sign \
+		--manifest $< \
+		--output $<.sgx
 
 benchmark_app.token: benchmark_app.sig
-	gramine-sgx-get-token --sig $< --output $@
+	gramine-sgx-get-token --output $@ --sig $<
 
 benchmark_app: $(OPENVINO_DIR)
 	mkdir -p $(INFERENCE_ENGINE_CPP_SAMPLES_BUILD)

--- a/pytorch/Makefile
+++ b/pytorch/Makefile
@@ -16,7 +16,7 @@ ifeq ($(SGX),1)
 all: pytorch.manifest.sgx pytorch.sig pytorch.token
 endif
 
-%.manifest: %.manifest.template
+pytorch.manifest: pytorch.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
@@ -24,20 +24,18 @@ endif
 		$< > $@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# we need to hack around.
-pytorch.sig pytorch.manifest.sgx: sgx_outputs
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+pytorch.manifest.sgx pytorch.sig: sgx_sign
 	@:
 
-.INTERMEDIATE: sgx_outputs
-sgx_outputs: pytorch.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
+.INTERMEDIATE: sgx_sign
+sgx_sign: pytorch.manifest
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
-		--output pytorch.manifest.sgx \
-		--manifest pytorch.manifest
+		--manifest $< \
+		--output $<.sgx
 
-%.token: %.sig
+pytorch.token: pytorch.sig
 	gramine-sgx-get-token --output $@ --sig $<
 
 .PHONY: clean

--- a/r/Makefile
+++ b/r/Makefile
@@ -29,17 +29,19 @@ R.manifest: R.manifest.template
 		-Dr_exec=$(R_EXEC) \
 		$< >$@
 
-%.manifest.sgx: %.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+R.manifest.sgx R.sig: sgx_sign
+	@:
+
+.INTERMEDIATE: sgx_sign
+sgx_sign: R.manifest
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
-		--output $@
+		--output $<.sgx
 
-R.sig: R.manifest.sgx
-
-%.token: %.sig
+R.token: R.sig
 	gramine-sgx-get-token --output $@ --sig $<
 
 ifeq ($(SGX),)

--- a/tensorflow-lite/.gitignore
+++ b/tensorflow-lite/.gitignore
@@ -3,6 +3,7 @@
 /inception_v3.pb
 /inception_v3.tflite
 /inception_v3_2018_04_27.tgz
+/label_image
 /labels.txt
 /tensorflow
 /tensorflow.tar.gz

--- a/tensorflow-lite/Makefile
+++ b/tensorflow-lite/Makefile
@@ -64,15 +64,20 @@ label_image.manifest: label_image.manifest.template libtensorflow_framework.so l
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		$< > $@
 
-label_image.manifest.sgx: label_image.manifest inception_v3.tflite labels.txt
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+label_image.manifest.sgx label_image.sig: sgx_sign
+	@:
+
+.INTERMEDIATE: sgx_sign
+sgx_sign: label_image.manifest inception_v3.tflite labels.txt
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
-		--output $@
-	gramine-sgx-get-token \
-		--output label_image.token --sig label_image.sig
+		--output $<.sgx
+
+label_image.token: label_image.sig
+	gramine-sgx-get-token --output $@ --sig $<
 
 .PHONY: check
 check: all


### PR DESCRIPTION
This is similar to https://github.com/gramineproject/gramine/pull/588

I tested everything locally on my machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/27)
<!-- Reviewable:end -->
