### PR TITLE
add mysql-server to gramine examples

### DIFF
--- a/mysql/Makefile
+++ b/mysql/Makefile
@@ -1,0 +1,35 @@
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+ifeq ($(DEBUG),1)
+GRAMINE_LOG_LEVEL = debug
+else
+GRAMINE_LOG_LEVEL = error
+endif
+
+.PHONY: all
+all: mysqld.manifest
+ifeq ($(SGX),1)
+all: mysqld.manifest.sgx mysqld.sig mysqld.token
+endif
+
+mysqld.manifest: mysqld.manifest.template
+	gramine-manifest \
+                -Dlog_level=$(GRAMINE_LOG_LEVEL) \
+                -Darch_libdir=$(ARCH_LIBDIR) \
+		-Dentrypoint=$(realpath $(shell sh -c "command -v mysqld")) \
+                $< >$@
+
+mysqld.manifest.sgx: mysqld.manifest
+	gramine-sgx-sign \
+                --manifest $< \
+                --output $@
+
+mysqld.token: mysqld.sig
+	gramine-sgx-get-token --output $@ --sig $<
+
+.PHONY: clean
+clean:
+	$(RM) *.token *.sig *.manifest.sgx *.manifest
+
+.PHONY: distclean
+distclean: clean

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,0 +1,59 @@
+# Mysql example
+# This example is tested with mysql Ver 8.0.29
+
+This directory contains an example for running Mysql-Server in Gramine, including
+the Makefile and a template for generating the manifest.
+
+# Prerequisites Steps
+
+## Install mysql-server on baremetal:
+    sudo apt-get install mysql-server
+
+## Comment log in /etc/mysql/mysql.conf.d/mysqld.cnf to see the logs on console:
+    #log_error = /var/log/mysql/error.log
+
+## Stop mysql service, we need to manually run mysql with mysqld:
+    systemctl stop mysql.service
+    sudo mkdir /var/run/mysqld && sudo chown -R <current_user>:<current_user> /var/run/mysqld
+    sudo chown -R <current_user>:<current_user> /var/lib/mysql-files
+    sudo chown -R <current_user>:<current_user> /var/lib/mysql-keyring
+
+## Prepare new data directory:
+    sudo mkdir /tmp/mysql && sudo chown -R <current_user>:<current_user> /tmp/mysql
+
+## Add the following 2 lines to /etc/apparmor.d/usr.sbin.mysqld:
+    /tmp/mysql r,
+    /tmp/mysql/** rwk,
+
+## Restart apparmor:
+    sudo service apparmor restart
+
+## Initialize mysql:
+    mysqld --initialize-insecure --datadir=/tmp/mysql
+    sudo rm /tmp/mysql/undo*
+
+# Generating the manifest
+
+## Installing prerequisites
+
+## Building for Linux
+
+Run `make` (non-debug) or `make DEBUG=1` (debug) in the directory.
+
+## Building for SGX
+
+Run `make SGX=1` (non-debug) or `make SGX=1 DEBUG=1` (debug) in the directory.
+
+# Run Mysql with Gramine
+
+Here's an example of running Mysql under Gramine:
+
+Without SGX:
+```
+gramine-direct mysqld -u root --datadir /tmp/mysql
+```
+
+With SGX:
+```
+gramine-sgx mysqld -u root --datadir /tmp/mysql
+```

--- a/mysql/mysqld.manifest.template
+++ b/mysql/mysqld.manifest.template
@@ -1,0 +1,44 @@
+# mysql manifest example
+loader.preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
+
+loader.entrypoint = "file:{{ gramine.libos }}"
+libos.entrypoint = "{{ entrypoint }}"
+
+loader.log_level = "{{ log_level }}"
+
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/{{ arch_libdir }}"
+loader.env.PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+loader.insecure__use_cmdline_argv = true
+sys.enable_sigterm_injection = true
+
+sgx.nonpie_binary = true
+sgx.enclave_size = "4G"
+sys.stack.size = "16M"
+sgx.thread_num = 64
+
+fs.mounts = [
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+  { path = "/usr", uri = "file:/usr" },
+  { path = "/var/lib/mysql-files", uri = "file:/var/lib/mysql-files" },
+  { path = "/var/lib/mysql-keyring", uri = "file:/var/lib/mysql-keyring" },
+  { path = "/var/run/mysqld", uri = "file:/var/run/mysqld" },
+  { path = "/tmp", uri = "file:/tmp" },
+]
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ entrypoint }}",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:/usr/lib/mysql/",
+  "file:/usr/share/mysql-8.0/",
+]
+
+sgx.allowed_files = [
+  "file:/var/run/mysqld/",
+  "file:/tmp/",
+]


### PR DESCRIPTION
Add mysql-server to gramine examples.

How to test:
Runing mysql server: Please follow the instructions to run mysql server in gramine
Connect Client to mysql server: mysql -P 3306 --protocol=tcp -uroot

Execute Sysbench benchmarking: 

sudo mysqladmin -h 127.0.0.1 -P 3306 create sbtest

Install sysbench if not installed: sudo apt install -y sysbench

sysbench --db-driver=mysql --mysql-host=127.0.0.1 --mysql-port=3306 --mysql-user=root --mysql-db=sbtest /usr/share/sysbench/oltp_common.lua --tables=10 --table_size=100000 prepare

sysbench --db-driver=mysql --mysql-host=127.0.0.1 --mysql-port=3306 --mysql-user=root --mysql-db=sbtest --threads=4 --time=20 --report-interval=5 /usr/share/sysbench/oltp_read_write.lua --tables=10 --table_size=100000 run
