### PR TITLE
Increase Curl enclave size to 512M

### DIFF
--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -18,7 +18,7 @@ fs.mounts = [
   { type = "chroot", uri = "file:{{ curl_dir }}", path = "{{ curl_dir }}" },
 ]
 
-sgx.enclave_size = "256M"
+sgx.enclave_size = "512M"
 sgx.thread_num = 4
 
 sgx.trusted_files = [


### PR DESCRIPTION
Enclave size of 256M is insufficient for Curl on CentOS/RHEL.

Signed-off-by: Aniket Borkar <aniketx.borkar@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/29)
<!-- Reviewable:end -->
