### PR TITLE
Remove `chroot` keyword in FS mounts in manifests

### DIFF
--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -11,11 +11,11 @@ loader.env.HOME = "{{ home }}"
 loader.insecure__use_cmdline_argv = true
 
 fs.mounts = [
-  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/usr/{{ arch_libdir }}", path = "/usr{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/etc", path = "/etc" },
-  { type = "chroot", uri = "file:{{ curl_dir }}", path = "{{ curl_dir }}" },
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr/{{ arch_libdir }}", path = "/usr{{ arch_libdir }}" },
+  { uri = "file:/etc", path = "/etc" },
+  { uri = "file:{{ curl_dir }}", path = "{{ curl_dir }}" },
 ]
 
 sgx.enclave_size = "512M"

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -12,11 +12,11 @@ loader.env.PATH = "/bin:/usr/bin"
 loader.insecure__use_cmdline_argv = true
 
 fs.mounts = [
-  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/usr", path = "/usr" },
-  { type = "chroot", uri = "file:/tmp", path = "/tmp" },
-  { type = "chroot", uri = "file:/lib64", path = "/lib64" },
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr", path = "/usr" },
+  { uri = "file:/tmp", path = "/tmp" },
+  { uri = "file:/lib64", path = "/lib64" },
 ]
 
 sgx.enclave_size = "1G"

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -14,10 +14,10 @@ loader.insecure__use_host_env = true
 sys.insecure__allow_eventfd = true
 
 fs.mounts = [
-  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:{{ nodejs_dir }}/nodejs", path = "{{ nodejs_dir }}/nodejs" },
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
+  { uri = "file:{{ nodejs_dir }}/nodejs", path = "{{ nodejs_dir }}/nodejs" },
 ]
 
 sgx.nonpie_binary = true

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -8,9 +8,9 @@ loader.insecure__use_cmdline_argv = true
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/{{ arch_libdir }}"
 
 fs.mounts = [
-  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/usr", path = "/usr" },
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr", path = "/usr" },
 ]
 
 # If using 64G or greater enclave sizes, the JVM flag `-Xmx8G` can be omitted in gramine-sgx.

--- a/openvino/README.md
+++ b/openvino/README.md
@@ -141,9 +141,7 @@ same time.
 - Install mimalloc using the steps from https://github.com/microsoft/mimalloc
 - Modify the manifest template file:
     - Add the `/usr/local` FS mount point:
-        - `fs.mount.usr_local.type = "chroot"`
-        - `fs.mount.usr_local.path = "/usr/local"`
-        - `fs.mount.usr_local.uri = "file:/usr/local"`
+        - `{ uri = "file:/usr/local", path = "/usr/local" }`
     - Add `loader.env.LD_PRELOAD = "/usr/local/lib/mimalloc-1.7/libmimalloc.so.1.7"`
     - Append below entry to `sgx.trusted_files`:
         - `"file:/usr/local/lib/mimalloc-1.7/libmimalloc.so.1.7"`

--- a/openvino/benchmark_app.manifest.template
+++ b/openvino/benchmark_app.manifest.template
@@ -6,12 +6,12 @@ loader.log_level = "{{ log_level }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ openvino_dir }}/deployment_tools/inference_engine/external/tbb/lib:{{ openvino_dir }}/deployment_tools/inference_engine/lib/intel64:{{ openvino_dir }}/opencv/lib:{{ openvino_dir }}/deployment_tools/ngraph/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
 fs.mounts = [
-  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/etc", path = "/etc" },
-  { type = "chroot", uri = "file:{{ openvino_dir }}", path = "{{ openvino_dir }}" },
-  { type = "chroot", uri = "file:{{ inference_engine_cpp_samples_build }}", path = "{{ inference_engine_cpp_samples_build }}" },
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
+  { uri = "file:/etc", path = "/etc" },
+  { uri = "file:{{ openvino_dir }}", path = "{{ openvino_dir }}" },
+  { uri = "file:{{ inference_engine_cpp_samples_build }}", path = "{{ inference_engine_cpp_samples_build }}" },
 ]
 
 loader.insecure__use_cmdline_argv = true

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -17,12 +17,12 @@ loader.insecure__use_host_env = true
 loader.pal_internal_mem_size = "128M"
 
 fs.mounts = [
-  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/usr", path = "/usr" },
-  { type = "chroot", uri = "file:/etc", path = "/etc" },
-  { type = "chroot", uri = "file:/tmp", path = "/tmp" },
-  { type = "chroot", uri = "file:{{ pillow_path }}", path = "{{ pillow_path }}" },
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr", path = "/usr" },
+  { uri = "file:/etc", path = "/etc" },
+  { uri = "file:/tmp", path = "/tmp" },
+  { uri = "file:{{ pillow_path }}", path = "{{ pillow_path }}" },
 ]
 
 # PyTorch loads its pre-trained models from here

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -18,17 +18,17 @@ loader.insecure__use_cmdline_argv = true
 sys.enable_sigterm_injection = true
 
 fs.mounts = [
-  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/usr", path = "/usr" },
-  { type = "chroot", uri = "file:/tmp", path = "/tmp" },
-  { type = "chroot", uri = "file:/bin", path = "/bin" },
-  { type = "chroot", uri = "file:{{ r_home }}", path = "{{ r_home }}" },
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr", path = "/usr" },
+  { uri = "file:/tmp", path = "/tmp" },
+  { uri = "file:/bin", path = "/bin" },
+  { uri = "file:{{ r_home }}", path = "{{ r_home }}" },
 ]
 
 sgx.nonpie_binary = true
 sys.stack.size = "8M"
-sgx.enclave_size = "2G"
+sgx.enclave_size = "2G"   # for the R-benchmark-25.R script, specify at least "16G"
 sgx.thread_num = 4
 
 sgx.trusted_files = [

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -11,9 +11,9 @@ loader.env.PATH = "/bin:/usr/bin"
 loader.insecure__use_cmdline_argv = true
 
 fs.mounts = [
-  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { type = "chroot", uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
+  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
 ]
 
 sgx.nonpie_binary = true


### PR DESCRIPTION
It is the default type anyway, and it is rather intuitive.

Requested by @mkow while reviewing the PyTorch tutorial: https://github.com/gramineproject/gramine/pull/635#pullrequestreview-1041025762 

All examples still work, tested manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/36)
<!-- Reviewable:end -->
