### PR TITLE
Replace chroot-based `/tmp/` with tmpfs-based one

### DIFF
--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -15,9 +15,14 @@ fs.mounts = [
   { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
   { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
   { uri = "file:/usr", path = "/usr" },
-  { uri = "file:/tmp", path = "/tmp" },
   { uri = "file:/lib64", path = "/lib64" },
+
+  # cannot replace /tmp with "tmpfs" mount because Gramine currently doesn't support multi-process
+  # "tmpfs" files (e.g., "tmpfs" files created in a child process are not visible in the parent)
+  { uri = "file:/tmp", path = "/tmp" },
 ]
+
+loader.pal_internal_mem_size = "64M"
 
 sgx.enclave_size = "1G"
 sgx.nonpie_binary = true
@@ -32,11 +37,10 @@ sgx.trusted_files = [
   "file:/usr/{{ arch_libdir }}/",
   "file:{{ gcc_lib_path }}/{{ gcc_major_version }}/",
   "file:/lib64/",
+  "file:/usr/include/",
 ]
 
 sgx.allowed_files = [
   "file:/tmp",
   "file:test_files",
-  "file:a.out",
-  "file:/usr/include",
 ]

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -21,8 +21,9 @@ fs.mounts = [
   { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
   { uri = "file:/usr", path = "/usr" },
   { uri = "file:/etc", path = "/etc" },
-  { uri = "file:/tmp", path = "/tmp" },
   { uri = "file:{{ pillow_path }}", path = "{{ pillow_path }}" },
+
+  { type = "tmpfs", path = "/tmp" },
 ]
 
 # PyTorch loads its pre-trained models from here
@@ -30,8 +31,8 @@ fs.mounts = [
 # { type = "chroot", uri = "file:{{ env.HOME }}/.cache/torch", path = "{{ env.HOME }}/.cache/torch" }
 
 sgx.nonpie_binary = true
-sgx.enclave_size = "16G"
-sgx.thread_num = 256
+sgx.enclave_size = "2G"
+sgx.thread_num = 16
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
@@ -45,29 +46,16 @@ sgx.trusted_files = [
   "file:{{ python.get_path('stdlib', vars={'installed_base': '/usr/local'}) }}/",
 
   "file:pytorchexample.py",
+
   "file:classes.txt",
   "file:input.jpg",
-
-  # Pre-trained model saved as a file
-  "file:alexnet-pretrained.pt",
+  "file:alexnet-pretrained.pt",  # Pre-trained model saved as a file
 
   # Uncomment line below if you want to use torchvision.model.alexnet(pretrained=True)
   # "file:{{ env.HOME }}/.cache/torch/checkpoints/alexnet-owt-4df8aa71.pth",
 ]
 
 sgx.allowed_files = [
-  "file:/tmp",
-  "file:/etc/apt/apt.conf.d",
-  "file:/etc/apt/apt.conf",
-  "file:/etc/default/apport",
-  "file:/etc/nsswitch.conf",
-  "file:/etc/group",
-  "file:/etc/passwd",
-  "file:/etc/host.conf",
-  "file:/etc/hosts",
-  "file:/etc/gai.conf",
-  "file:/etc/resolv.conf",
-  "file:/etc/fstab",
   "file:result.txt",
 ]
 

--- a/pytorch/pytorchexample.py
+++ b/pytorch/pytorchexample.py
@@ -46,3 +46,5 @@ percentage = torch.nn.functional.softmax(out, dim=1)[0] * 100
 # Print the 5 most likely predictions.
 with open("result.txt", "w") as outfile:
     outfile.write(str([(classes[idx], percentage[idx].item()) for idx in indices[0][:5]]))
+
+print("Done. The result was written to `result.txt`.")

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -21,9 +21,10 @@ fs.mounts = [
   { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
   { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
   { uri = "file:/usr", path = "/usr" },
-  { uri = "file:/tmp", path = "/tmp" },
   { uri = "file:/bin", path = "/bin" },
   { uri = "file:{{ r_home }}", path = "{{ r_home }}" },
+
+  { type = "tmpfs", path = "/tmp" },
 ]
 
 sgx.nonpie_binary = true
@@ -44,8 +45,4 @@ sgx.trusted_files = [
   # strace snippet: execve("/bin/sh", ["sh", "-c", "rm -rf /tmp/RtmpEiedDF"], [/* 41 vars */])
   "file:/bin/rm",
   "file:/bin/sh",
-]
-
-sgx.allowed_files = [
-  "file:/tmp",
 ]


### PR DESCRIPTION
This removes the need to add `/tmp/` dir to the list of `sgx.allowed_files`. As a side effect, this commit cleans up `sgx.allowed_files` in GCC and PyTorch examples.

I tested the changes manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/37)
<!-- Reviewable:end -->
