### PR TITLE
Increase Pytorch enclave size and thread number

### DIFF
--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -31,8 +31,8 @@ fs.mounts = [
 # { type = "chroot", uri = "file:{{ env.HOME }}/.cache/torch", path = "{{ env.HOME }}/.cache/torch" }
 
 sgx.nonpie_binary = true
-sgx.enclave_size = "2G"
-sgx.thread_num = 16
+sgx.enclave_size = "4G"
+sgx.thread_num = 32
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",


### PR DESCRIPTION
2G enclave size is not sufficient for servers, hence increasing it to 4G

Signed-off-by: Anjali Rai <anjali.rai@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/38)
<!-- Reviewable:end -->
