### PR TITLE
Limit the number of threads for R example

### DIFF
--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -12,6 +12,7 @@ loader.env.HOME = ""
 loader.env.PWD = ""
 loader.env.R_ARCH = ""
 loader.env.R_HOME = "{{ r_home }}"
+loader.env.OMP_NUM_THREADS = "4"
 
 loader.insecure__use_cmdline_argv = true
 


### PR DESCRIPTION
With the latest Patched R version 4.2.1, In centos server it is allocating memory to each CPU and because of this Gramine has ran out of memory, To avoid that limiting the number of threads to 4.

Signed-off-by: Anjali Rai <anjali.rai@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/40)
<!-- Reviewable:end -->
