### PR TITLE
Replace `sgx.thread_num` with `sgx.max_threads` in example manifests

### DIFF
--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -19,7 +19,7 @@ fs.mounts = [
 ]
 
 sgx.enclave_size = "512M"
-sgx.thread_num = 4
+sgx.max_threads = 4
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -20,10 +20,11 @@ fs.mounts = [
   { uri = "file:{{ nodejs_dir }}/nodejs", path = "{{ nodejs_dir }}/nodejs" },
 ]
 
-sgx.nonpie_binary = true
 # Node.js expects around 1.7GB of heap on startup, see https://github.com/nodejs/node/issues/13018
 sgx.enclave_size = "2G"
-sgx.thread_num = 32
+
+sgx.nonpie_binary = true
+sgx.max_threads = 32
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -17,7 +17,7 @@ fs.mounts = [
 sgx.enclave_size = "16G"
 
 # SGX needs minimum 64 threads for loading OpenJDK runtime.
-sgx.thread_num = 64
+sgx.max_threads = 64
 
 # `require_exinfo = true` is needed because OpenJDK queries fault info on page faults
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}

--- a/openvino/benchmark_app.manifest.template
+++ b/openvino/benchmark_app.manifest.template
@@ -17,7 +17,7 @@ fs.mounts = [
 loader.insecure__use_cmdline_argv = true
 
 sgx.enclave_size = "32G"
-sgx.thread_num = 196
+sgx.max_threads = 196
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.preheat_enclave = {{ 'false' if env.get('EDMM', '0') == '1' else 'true' }}

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -32,7 +32,7 @@ fs.mounts = [
 
 sgx.nonpie_binary = true
 sgx.enclave_size = "4G"
-sgx.thread_num = 32
+sgx.max_threads = 32
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -31,7 +31,7 @@ fs.mounts = [
 sgx.nonpie_binary = true
 sys.stack.size = "8M"
 sgx.enclave_size = "2G"   # for the R-benchmark-25.R script, specify at least "16G"
-sgx.thread_num = 8
+sgx.max_threads = 8
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [

--- a/scikit-learn-intelex/sklearnex.manifest.template
+++ b/scikit-learn-intelex/sklearnex.manifest.template
@@ -39,7 +39,7 @@ fs.mounts = [
 
 sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
-sgx.thread_num = 128
+sgx.max_threads = 128
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -18,7 +18,7 @@ fs.mounts = [
 
 sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
-sgx.thread_num = 16
+sgx.max_threads = 16
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [


### PR DESCRIPTION
See https://github.com/gramineproject/gramine/pull/982.

Use `dimakuv/replace-num-thread-with-max-threads` branch in core Gramine for testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/41)
<!-- Reviewable:end -->
