### PR TITLE
Increase the number of sgx.max_threads to 8

### DIFF
--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -31,7 +31,7 @@ fs.mounts = [
 sgx.nonpie_binary = true
 sys.stack.size = "8M"
 sgx.enclave_size = "2G"   # for the R-benchmark-25.R script, specify at least "16G"
-sgx.thread_num = 4
+sgx.thread_num = 8
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",


### PR DESCRIPTION
R on Ubuntu 22.04 requires more threads than specified in OMP_NUM_THREADS because it spawns some additional helper threads.

Signed-off-by: Anjali Rai <anjali.rai@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/43)
<!-- Reviewable:end -->
