### PR TITLE
Fix comment on OpenMP usage in PyTorch example

### DIFF
--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -59,12 +59,10 @@ sgx.allowed_files = [
   "file:result.txt",
 ]
 
-# Gramine optionally provides patched OpenMP runtime library that runs faster
-# inside SGX enclaves (execute `make -C LibOS gcc` to generate it). Uncomment
-# the lines below to use the patched library. PyTorch's SGX perf overhead
-# decreases on some workloads from 25% to 8% with this patched library. Note
-# that we need to preload the library because PyTorch's distribution renames
-# libgomp.so to smth like libgomp-7c85b1e2.so.1, so it's not just a matter of
-# searching in the Gramine's Runtime path first, but a matter of intercepting
-# OpenMP functions.
+# Gramine optionally provides patched OpenMP runtime library that runs faster inside SGX enclaves
+# (add `-Dlibgomp=enabled` when configuring the build). Uncomment the line below to use the patched
+# library. PyTorch's SGX perf overhead decreases on some workloads from 25% to 8% with this patched
+# library. Note that we need to preload the library because PyTorch's distribution renames
+# libgomp.so to smth like libgomp-7c85b1e2.so.1, so it's not just a matter of searching in the
+# Gramine's Runtime path first, but a matter of intercepting OpenMP functions.
 # loader.env.LD_PRELOAD = "/lib/libgomp.so.1"


### PR DESCRIPTION
The comment was stale, from the times when Gramine used Makefiles for build. Now that Gramine uses Meson for build, the correct way of enabling our patched OpenMP lib is to add `-Dlibgomp=enabled` during `meson setup`.

We actually have the right comment in the core Gramine repo: https://github.com/gramineproject/gramine/blob/4e724c10210a435c8837875fe2a4e8e50257b9c9/libos/test/regression/openmp.manifest.template#L4-L6. But we forgot to update the comment in this Examples repo.

As a side effect, I also changed wrapping from 80-chars-per-line to 100-chars-per-line.

See [#1079](https://github.com/gramineproject/gramine/issues/1079).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/45)
<!-- Reviewable:end -->
