### PR TITLE
[CI-Examples] Add EDMM Support in manifest files

### DIFF
--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -20,6 +20,7 @@ fs.mounts = [
 
 sgx.enclave_size = "512M"
 sgx.thread_num = 4
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -26,6 +26,7 @@ loader.pal_internal_mem_size = "64M"
 
 sgx.enclave_size = "1G"
 sgx.nonpie_binary = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -24,6 +24,7 @@ sgx.nonpie_binary = true
 # Node.js expects around 1.7GB of heap on startup, see https://github.com/nodejs/node/issues/13018
 sgx.enclave_size = "2G"
 sgx.thread_num = 32
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -19,6 +19,10 @@ sgx.enclave_size = "16G"
 # SGX needs minimum 64 threads for loading OpenJDK runtime.
 sgx.thread_num = 64
 
+# `require_exinfo = true` is needed because OpenJDK queries fault info on page faults
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+sgx.require_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ entrypoint }}",

--- a/openvino/benchmark_app.manifest.template
+++ b/openvino/benchmark_app.manifest.template
@@ -18,8 +18,9 @@ loader.insecure__use_cmdline_argv = true
 
 sgx.enclave_size = "32G"
 sgx.thread_num = 196
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
-sgx.preheat_enclave = true
+sgx.preheat_enclave = {{ 'false' if env.get('EDMM', '0') == '1' else 'true' }}
 libos.check_invalid_pointers = false
 
 sgx.trusted_files = [

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -33,6 +33,7 @@ fs.mounts = [
 sgx.nonpie_binary = true
 sgx.enclave_size = "4G"
 sgx.thread_num = 32
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -32,6 +32,7 @@ sgx.nonpie_binary = true
 sys.stack.size = "8M"
 sgx.enclave_size = "2G"   # for the R-benchmark-25.R script, specify at least "16G"
 sgx.thread_num = 8
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/scikit-learn-intelex/sklearnex.manifest.template
+++ b/scikit-learn-intelex/sklearnex.manifest.template
@@ -40,6 +40,7 @@ fs.mounts = [
 sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
 sgx.thread_num = 128
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -19,6 +19,7 @@ fs.mounts = [
 sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sgx.thread_num = 16
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",


### PR DESCRIPTION
Add EDMM support in manifest files.
Increasing wait time for server because workloads takes 2x-5x times to execute with EDMM than non-EDMM.

Signed-off-by: Anjali Rai <anjali.rai@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/47)
<!-- Reviewable:end -->
