### PR TITLE
Fix deprecation warning in PyTorch example

### DIFF
--- a/pytorch/download-pretrained-model.py
+++ b/pytorch/download-pretrained-model.py
@@ -2,7 +2,7 @@ from torchvision import models
 import torch
 
 output_filename = "alexnet-pretrained.pt"
-alexnet = models.alexnet(pretrained=True)
+alexnet = models.alexnet(weights=models.AlexNet_Weights.IMAGENET1K_V1)
 torch.save(alexnet, output_filename)
 
 print("Pre-trained model was saved in \"%s\"" % output_filename)


### PR DESCRIPTION
PyTorch example report below warning with command `python3 download-pretrained-model.py` in prerequisites:

`/home/xxx/.local/lib/python3.8/site-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
  warnings.warn(
/home/xxx/.local/lib/python3.8/site-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=AlexNet_Weights.IMAGENET1K_V1`. You can also use `weights=AlexNet_Weights.DEFAULT` to get the most up-to-date weights.
  warnings.warn(msg)
Pre-trained model was saved in "alexnet-pretrained.pt"`

PR fixes this warning.