### PR TITLE
Remove redundant `sgx.nonpie_binary` manifest option

### DIFF
--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -25,7 +25,6 @@ fs.mounts = [
 loader.pal_internal_mem_size = "64M"
 
 sgx.enclave_size = "1G"
-sgx.nonpie_binary = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -23,7 +23,6 @@ fs.mounts = [
 # Node.js expects around 1.7GB of heap on startup, see https://github.com/nodejs/node/issues/13018
 sgx.enclave_size = "2G"
 
-sgx.nonpie_binary = true
 sgx.max_threads = 32
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -30,7 +30,6 @@ fs.mounts = [
 # Add below uncommented line to fs.mounts array if you want to use torchvision.model.alexnet(pretrained=True)
 # { type = "chroot", uri = "file:{{ env.HOME }}/.cache/torch", path = "{{ env.HOME }}/.cache/torch" }
 
-sgx.nonpie_binary = true
 sgx.enclave_size = "4G"
 sgx.max_threads = 32
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -28,7 +28,6 @@ fs.mounts = [
   { type = "tmpfs", path = "/tmp" },
 ]
 
-sgx.nonpie_binary = true
 sys.stack.size = "8M"
 sgx.enclave_size = "2G"   # for the R-benchmark-25.R script, specify at least "16G"
 sgx.max_threads = 8

--- a/scikit-learn-intelex/sklearnex.manifest.template
+++ b/scikit-learn-intelex/sklearnex.manifest.template
@@ -37,7 +37,6 @@ fs.mounts = [
   { type = "tmpfs", path = "/tmp" },
 ]
 
-sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
 sgx.max_threads = 128
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -16,7 +16,6 @@ fs.mounts = [
   { uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
 ]
 
-sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sgx.max_threads = 16
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}


### PR DESCRIPTION
This is a PR corresponding to "Remove redundant `sgx.nonpie_binary` manifest option" commit in core Gramine.

See https://github.com/gramineproject/gramine/pull/1187.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/54)
<!-- Reviewable:end -->
