### PR TITLE
Add distro and torchvision version used to test PyTorch example

### DIFF
--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -1,5 +1,7 @@
 # PyTorch
 
+This example was tested with torchvision version 0.13.0 and Ubuntu 20.04.
+
 This directory contains steps and artifacts to run a PyTorch sample workload on
 Gramine. Specifically, this example uses a pre-trained model for image
 classification.


### PR DESCRIPTION
Commit [2e41bcd](https://github.com/gramineproject/examples/commit/2e41bcd1d1887a364fced4bd220e654c9ae41ff0) broke pytorch example in `ubuntu 18.04`. Changes in above commit works with `torchvision version 0.13.0` or above which is available with `python 3.7` and above. But `ubuntu 18.04` comes with `python3.6.9` where `torchvision 0.13.0` cannot be installed.

More info about torchvision versions compatibility with python version https://pypi.org/project/torchvision/

Changes in this PR inform user about the torchvison version and dostro used for testing this example. We don't necessarility have to make it work with `ubuntu 18.04` as it's reaching EOF in 1 month.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/55)
<!-- Reviewable:end -->
