### PR TITLE
Allow new- and old-style download of models in PyTorch example

### DIFF
--- a/pytorch/download-pretrained-model.py
+++ b/pytorch/download-pretrained-model.py
@@ -2,7 +2,13 @@ from torchvision import models
 import torch
 
 output_filename = "alexnet-pretrained.pt"
-alexnet = models.alexnet(weights=models.AlexNet_Weights.IMAGENET1K_V1)
+
+try:
+    alexnet = models.alexnet(weights=models.AlexNet_Weights.IMAGENET1K_V1)
+except AttributeError:
+    # older versions of torchvision (less than 0.13.0) use below now-deprecated parameter
+    alexnet = models.alexnet(pretrained=True)
+
 torch.save(alexnet, output_filename)
 
 print("Pre-trained model was saved in \"%s\"" % output_filename)


### PR DESCRIPTION
Previous commit "Fix deprecation warning in PyTorch example" (https://github.com/gramineproject/examples/commit/2e41bcd1d1887a364fced4bd220e654c9ae41ff0) broke the PyTorch example on Ubuntu 18.04, CentOS 8, RHEL 8, etc. Changes in that commit work with torchvision 0.13.0+ which is available with Python 3.7+ only, however e.g. Ubuntu 18.04 comes with Python 3.6, hence torchvision 0.13.0+ cannot be installed on Ubuntu 18.04.

To allow such older OS distros, this PR allows both styles of downloading models.

Fixes #53. Closes #55.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/56)
<!-- Reviewable:end -->
