### PR TITLE
Update PyTorch manifest template

### DIFF
--- a/pytorch/Makefile
+++ b/pytorch/Makefile
@@ -4,9 +4,6 @@
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-# PyTorch uses the Pillow backend; detect where Pillow was installed
-PILLOW_PATH ?= $(shell pip3 show pillow | grep Location: | cut -d" " -f2)/
-
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 else
@@ -22,7 +19,6 @@ endif
 pytorch.manifest: pytorch.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
-		-Dpillow_path=$(PILLOW_PATH) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		-Dentrypoint=$(realpath $(shell sh -c "command -v python3")) \
 		$< > $@

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -24,12 +24,12 @@ installation.
   DNS-resolver libraries.
 - `sudo apt install python3-pip lsb-release` to install `pip` and `lsb_release`.
   The former is required to install additional Python packages while the latter
-is used by the Makefile.
+  is used by the Makefile.
 - `pip3 install --user torchvision pillow` to install the torchvision and pillow
   Python packages and their dependencies (usually in $HOME/.local). WARNING:
-This downloads several hundred megabytes of data!
+  This downloads several hundred megabytes of data!
 - `python3 download-pretrained-model.py` to download and save the pre-trained
-  model.  WARNING: this downloads about 200MB of data!
+  model. WARNING: this downloads about 200MB of data!
 
 # Build
 

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -7,52 +7,46 @@ libos.entrypoint = "{{ entrypoint }}"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:/usr/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+loader.env.HOME = "{{ env.HOME }}"
 
 # Restrict the maximum number of threads to prevent insufficient memory
 # issue, observed on CentOS/RHEL.
 loader.env.OMP_NUM_THREADS = "8"
 
 loader.insecure__use_cmdline_argv = true
-loader.insecure__use_host_env = true
 
 fs.mounts = [
-  { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
-  { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
-  { uri = "file:/usr", path = "/usr" },
-  { uri = "file:/etc", path = "/etc" },
-  { uri = "file:{{ pillow_path }}", path = "{{ pillow_path }}" },
+  { path = "{{ entrypoint }}", uri = "file:{{ entrypoint }}" },
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+{% for path in python.get_sys_path(entrypoint) %}
+  { path = "{{ path }}", uri = "file:{{ path }}" },
+{% endfor %}
 
   { type = "tmpfs", path = "/tmp" },
 ]
-
-# PyTorch loads its pre-trained models from here
-# Add below uncommented line to fs.mounts array if you want to use torchvision.model.alexnet(pretrained=True)
-# { type = "chroot", uri = "file:{{ env.HOME }}/.cache/torch", path = "{{ env.HOME }}/.cache/torch" }
 
 sgx.enclave_size = "4G"
 sgx.max_threads = 32
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ entrypoint }}",
+  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
-  "file:{{ python.stdlib }}/",
-  "file:{{ python.distlib }}/",
-  "file:{{ pillow_path }}",
-  "file:{{ python.get_path('stdlib', vars={'installed_base': '/usr/local'}) }}/",
+{% for path in python.get_sys_path(entrypoint) %}
+  "file:{{ path }}{{ '/' if path.is_dir() else '' }}",
+{% endfor %}
 
   "file:pytorchexample.py",
 
   "file:classes.txt",
   "file:input.jpg",
   "file:alexnet-pretrained.pt",  # Pre-trained model saved as a file
-
-  # Uncomment line below if you want to use torchvision.model.alexnet(pretrained=True)
-  # "file:{{ env.HOME }}/.cache/torch/checkpoints/alexnet-owt-4df8aa71.pth",
 ]
 
 sgx.allowed_files = [


### PR DESCRIPTION
~~OLD TEXT: PyTorch README describes local (non-root) installation. However, the manifest template worked only with system-wide (root) installation. This was because Gramine couldn't find where `torchvision` was installed.~~

This PR has several fixes:

- removed `loader.insecure__use_host_env`,
- removed deprecated `loader.pal_internal_mem_size`,
- removed stale commented-out manifest options,
- use `python.get_sys_path()` to list Python system paths,
- add `torchvision` local path: this fixes non-root installation.

Local installation on my random Ubuntu 22.04 machine is like this:
```
~/examples/pytorch$ pip3 show torchvision pillow
Name: torchvision
Version: 0.15.1
...
Location: /home/sdp/.local/lib/python3.10/site-packages
---
Name: Pillow
Version: 9.0.1
...
Location: /usr/lib/python3/dist-packages
```

The system-wide installation on the same machine is like this:
```

~/examples/pytorch$ sudo pip3 show torchvision pillow
Name: torchvision
Version: 0.15.1
...
Location: /usr/local/lib/python3.10/dist-packages
---
Name: Pillow
Version: 9.0.1
...
Location: /usr/lib/python3/dist-packages
```

For context, see also:
- https://github.com/gramineproject/examples/issues/31
- https://github.com/gramineproject/examples/pull/39

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/63)
<!-- Reviewable:end -->
