### PR TITLE
Remove `loader.pal_internal_mem_size` from all examples

### DIFF
--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -22,8 +22,6 @@ fs.mounts = [
   { uri = "file:/tmp", path = "/tmp" },
 ]
 
-loader.pal_internal_mem_size = "64M"
-
 sgx.enclave_size = "1G"
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -14,8 +14,6 @@ loader.env.OMP_NUM_THREADS = "8"
 loader.insecure__use_cmdline_argv = true
 loader.insecure__use_host_env = true
 
-loader.pal_internal_mem_size = "128M"
-
 fs.mounts = [
   { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
   { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },

--- a/scikit-learn-intelex/sklearnex.manifest.template
+++ b/scikit-learn-intelex/sklearnex.manifest.template
@@ -15,8 +15,6 @@ loader.env.OMP_NUM_THREADS = "8"
 loader.uid = {{ env_user_uid }}
 loader.gid = {{ env_user_gid }}
 
-loader.pal_internal_mem_size = "128M"
-
 sys.stack.size = "8M"
 sys.enable_extra_runtime_domain_names_conf = true
 


### PR DESCRIPTION
This manifest option was [removed in Gramine v1.4](https://github.com/gramineproject/gramine/releases/tag/v1.4).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/65)
<!-- Reviewable:end -->
