### PR TITLE
Update Scikit-learn manifest template

### DIFF
--- a/scikit-learn-intelex/sklearnex.manifest.template
+++ b/scikit-learn-intelex/sklearnex.manifest.template
@@ -34,6 +34,11 @@ fs.mounts = [
   # specify this prefix in LD_LIBRARY_PATH envvar above
   { path = "/home/user/.local/lib", uri = "file:{{ env.HOME }}/.local/lib" },
 
+  # Scikit imports pandas which in turn relies on the pytz library. The newer pytz versions fail if
+  # they cannot find files under /usr/share/zoneinfo (found on pytz version 2022.1, installed by
+  # apt).
+  { path = "/usr/share/zoneinfo/", uri = "file:/usr/share/zoneinfo/" },
+
   { type = "tmpfs", path = "/tmp" },
 ]
 
@@ -53,4 +58,5 @@ sgx.trusted_files = [
   "file:{{ env.HOME }}/.local/lib/",
   "file:data/",
   "file:scripts/",
+  "file:/usr/share/zoneinfo/",
 ]


### PR DESCRIPTION
Scikit depends on pandas which rely on pytz library, pytz installed by apt requires timezone info to be mounted

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/70)
<!-- Reviewable:end -->
