### PR TITLE
Add /usr/lib to PyTorch manifest

### DIFF
--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -7,7 +7,10 @@ libos.entrypoint = "{{ entrypoint }}"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+# In Debian12 we install torchvision via apt, which installs python3-torchvision
+# (0.14.1-2) at /usr/lib/ which is missing in the manifest template, causing pytorch
+# to fail with Gramine.
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}:/usr/lib"
 loader.env.HOME = "{{ env.HOME }}"
 
 # Restrict the maximum number of threads to prevent insufficient memory
@@ -26,6 +29,7 @@ fs.mounts = [
 {% endfor %}
 
   { type = "tmpfs", path = "/tmp" },
+  { path = "/usr/lib", uri = "file:/usr/lib" },
 ]
 
 sgx.enclave_size = "4G"
@@ -47,6 +51,7 @@ sgx.trusted_files = [
   "file:classes.txt",
   "file:input.jpg",
   "file:alexnet-pretrained.pt",  # Pre-trained model saved as a file
+  "file:/usr/lib/",
 ]
 
 sgx.allowed_files = [


### PR DESCRIPTION
PyTorch when installed via apt on Debian12 fails with `libgloo0` import error as /usr/lib path (where the lib and some others are installed) is missing in manifest file. This PR adds `/usr/lib` path to `LD_LIBRARY_PATH`, `fs.mounts` and `sgx.trusted_files`