### PR TITLE
Update Node.js to work on Debian 12

### DIFF
--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -22,6 +22,7 @@ nodejs.manifest: nodejs.manifest.template
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		-Dnodejs_dir=$(NODEJS_DIR) \
+		-Dnodejs_usr_share_dir=$(wildcard /usr/share/nodejs) \
 		$< >$@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -20,6 +20,9 @@ fs.mounts = [
   { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
   { uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
   { uri = "file:{{ nodejs_dir }}/nodejs", path = "{{ nodejs_dir }}/nodejs" },
+{%- if nodejs_usr_share_dir %}
+  { uri = "file:{{ nodejs_usr_share_dir }}", path = "{{ nodejs_usr_share_dir }}" },
+{%- endif %}
 ]
 
 # Node.js expects around 1.7GB of heap on startup, see https://github.com/nodejs/node/issues/13018
@@ -31,6 +34,9 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ nodejs_dir }}/nodejs",
+{%- if nodejs_usr_share_dir %}
+  "file:{{ nodejs_usr_share_dir }}/",
+{%- endif %}
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",


### PR DESCRIPTION
On Debian12, Node.js is of version 18.13 which loads files from under `/usr/share/nodejs/`. The manifest template must allow this dir.

Found by @jinengandhi-intel, thanks to him.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/73)
<!-- Reviewable:end -->
