### PR TITLE
Remove `sgx.debug` from MongoDB manifest template

### DIFF
--- a/mongodb/mongod.manifest.template
+++ b/mongodb/mongod.manifest.template
@@ -15,9 +15,7 @@ fs.mounts = [
   { path = "/data/db", uri = "file:data/db" },
 ]
 
-sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-
 sgx.enclave_size = "4G"
 sgx.max_threads = 64
 


### PR DESCRIPTION
All other examples in the repo don't have this manifest option.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/76)
<!-- Reviewable:end -->
