### PR TITLE
OpenJDK: Rename `sgx.require_exinfo` to `sgx.use_exinfo`

### DIFF
--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -21,9 +21,9 @@ sgx.enclave_size = "16G"
 # SGX needs minimum 64 threads for loading OpenJDK runtime.
 sgx.max_threads = 64
 
-# `require_exinfo = true` is needed because OpenJDK queries fault info on page faults
+# `use_exinfo = true` is needed because OpenJDK queries fault info on page faults
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.require_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",


### PR DESCRIPTION
Gramine renamed this manifest option as the old name was ambiguous.

See [#881](https://github.com/gramineproject/gramine/pull/881)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/77)
<!-- Reviewable:end -->
