### PR TITLE
Add `sgx.use_exinfo` to manifest templates

### DIFF
--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -25,6 +25,10 @@ sgx.enclave_size = "512M"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
+# `use_exinfo = true` is needed because the application may trigger lazy allocation of pages
+# (through exception handling) when EDMM is enabled
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ curl_dir }}/curl",

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -28,6 +28,10 @@ fs.mounts = [
 sgx.enclave_size = "1G"
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
+# `use_exinfo = true` is needed because the application may trigger lazy allocation of pages
+# (through exception handling) when EDMM is enabled
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:/usr/bin/gcc",

--- a/iperf/iperf3.manifest.template
+++ b/iperf/iperf3.manifest.template
@@ -33,6 +33,10 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '4' }}
 sgx.enclave_size = "1024M"
 
+# `use_exinfo = true` is needed because the application may trigger lazy allocation of pages
+# (through exception handling) when EDMM is enabled
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:install/iperf3",
   "file:install/libiperf.so.0",

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -29,6 +29,10 @@ sgx.enclave_size = "2G"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '32' }}
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
+# `use_exinfo = true` is needed because Node.js uses memory mappings with `MAP_NORESERVE`, which
+# will defer page accepts to page-fault events when EDMM is enabled
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ nodejs_dir }}/nodejs",

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -34,6 +34,10 @@ sgx.enclave_size = "4G"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '32' }}
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
+# `use_exinfo = true` is needed because the application may trigger lazy allocation of pages
+# (through exception handling) when EDMM is enabled
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ entrypoint }}",
   "file:{{ gramine.libos }}",

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -36,6 +36,10 @@ sgx.enclave_size = "2G"   # for the R-benchmark-25.R script, specify at least "1
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '8' }}
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
+# `use_exinfo = true` is needed because the application may trigger lazy allocation of pages
+# (through exception handling) when EDMM is enabled
+sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ r_exec }}",


### PR DESCRIPTION
`Curl`, `gcc`, `iperf`, `Node.js`, `PyTorch` and `R` may trigger lazy
allocation of pages (through exception handling) when EDMM is enabled.
So `sgx.use_exinfo = 1` needs to be added in the respective manifest
templates.

Needs https://github.com/gramineproject/gramine/pull/1513 and https://github.com/gramineproject/examples/pull/77 (https://github.com/gramineproject/gramine/pull/881) to be merged before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/78)
<!-- Reviewable:end -->
