### PR TITLE
OpenJDK: Always enable `sgx.use_exinfo` in manifest

### DIFF
--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -21,9 +21,10 @@ sgx.enclave_size = "16G"
 # SGX needs minimum 64 threads for loading OpenJDK runtime.
 sgx.max_threads = 64
 
-# `use_exinfo = true` is needed because OpenJDK queries fault info on page faults
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
+# `use_exinfo = true` is needed because OpenJDK queries fault info on page faults
+sgx.use_exinfo = true
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",


### PR DESCRIPTION
Since OpenJDK requires fault info on page faults, this change allows us to run it on platforms with EDMM disabled but do have EXINFO support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/79)
<!-- Reviewable:end -->
