### PR TITLE
Change the license of all examples to BSD-3-clause 

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,165 +1,26 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+Copyright 2024 Gramine contributors
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
 
-  0. Additional Definitions.
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
-
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/common_tools/download
+++ b/common_tools/download
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 set -eu -o pipefail
 

--- a/common_tools/wait_for_server
+++ b/common_tools/wait_for_server
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 set -eu
 

--- a/curl/Makefile
+++ b/curl/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 CURL_DIR ?= /usr/bin

--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Curl manifest file example
 

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 THIS_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # This is a general manifest template for running GCC and its utility programs,
 # including as, cc1, collect2, ld.

--- a/mongodb/Makefile
+++ b/mongodb/Makefile
@@ -1,3 +1,6 @@
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)

--- a/mongodb/mongod.manifest.template
+++ b/mongodb/mongod.manifest.template
@@ -1,3 +1,6 @@
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ execdir }}/mongod"
 

--- a/mongodb/scripts/fetch.js
+++ b/mongodb/scripts/fetch.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 Gramine contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
 const db = connect("mongodb://localhost:27017/mydatabase");
 
 const products = db.products;

--- a/mongodb/scripts/insert.js
+++ b/mongodb/scripts/insert.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 Gramine contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
 const db = connect("mongodb://localhost:27017/mydatabase");
 
 const products = db.products;

--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 NODEJS_DIR ?= /usr/bin

--- a/nodejs/helloworld.js
+++ b/nodejs/helloworld.js
@@ -1,1 +1,4 @@
+// Copyright (C) 2024 Gramine contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
 console.log("Hello World");

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Node.js manifest file example
 

--- a/openjdk/Makefile
+++ b/openjdk/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"

--- a/openvino/Makefile
+++ b/openvino/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 SHELL := /bin/bash # use bash syntax to activate virtual environment and to download models
 

--- a/openvino/benchmark_app.manifest.template
+++ b/openvino/benchmark_app.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "benchmark_app"

--- a/pytorch/Makefile
+++ b/pytorch/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # PyTorch and the pre-trained model must be installed on the system. See README for details.
 

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # PyTorch manifest template
 

--- a/r/Makefile
+++ b/r/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Installation location of R. By default, Gramine will run the system R executable.
 R_HOME ?= /usr/lib/R

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # R manifest example
 

--- a/scikit-learn-intelex/Makefile
+++ b/scikit-learn-intelex/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 

--- a/scikit-learn-intelex/run_tests.sh
+++ b/scikit-learn-intelex/run_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 set -e
 

--- a/scikit-learn-intelex/sklearnex.manifest.template
+++ b/scikit-learn-intelex/sklearnex.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Intel(R) Extension for Scikit-learn* manifest example
 

--- a/tensorflow-lite/Makefile
+++ b/tensorflow-lite/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 manifests = $(addsuffix .manifest,label_image)
 exec_target = $(manifests)

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2024 Gramine contributors
+# SPDX-License-Identifier: BSD-3-Clause
 
 # TensorFlow Lite example
 


### PR DESCRIPTION
The examples had the default license of LGPL-3.0. With this commit, we change the license of all Makefiles, manifest templates, config files, and some scripts in examples to a BSD-3-clause license.

This change is permitted by the "Examples Exception" to the Technical Charter, enacted on 5. December 2023. This change was agreed by all contributors to examples, past and present.

This change is in response to a popular request to adopt a more permissive license for our examples. The new BSD-3-clause is a permissive license (in contrast to the prevoiusly applied copyleft LGPL license). BSD explicitly allows to modify and use our examples without any obligation to share these modifications.

This commit is a counterpart to the commit "[CI-Examples] Add the BSD-3-clause license to all examples" in the core Gramine repo. See https://github.com/gramineproject/gramine/pull/1657.

For details, see also:
- https://github.com/gramineproject/gramine/discussions/1644
- https://github.com/gramineproject/gramine/discussions/1656
- https://github.com/gramineproject/gramine/pull/1670

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/90)
<!-- Reviewable:end -->
