### PR TITLE
MongoDB and Node.js: remove `sys.insecure__allow_eventfd`

### DIFF
--- a/mongodb/mongod.manifest.template
+++ b/mongodb/mongod.manifest.template
@@ -33,11 +33,5 @@ sgx.allowed_files = [
   "file:data/db/",    # MongoDB data will be stored in plaintext; this is insecure!
 ]
 
-# MongoDB requires eventfd, and the Gramine implementation
-# currently relies on the host in an insecure manner. This setting isn't
-# suitable for production deployment, but works well as a stopgap during
-# development while a proper implementation in Gramine is being worked on.
-sys.insecure__allow_eventfd = true
-
 # BSD (flock) locks are currently experimental
 sys.experimental__enable_flock = true

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -13,9 +13,6 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 loader.insecure__use_cmdline_argv = true
 loader.insecure__use_host_env = true
 
-# Node.js requires eventfd2() emulation otherwise fails on `(uv_loop_init(&tracing_loop_)) == (0)'
-sys.insecure__allow_eventfd = true
-
 fs.mounts = [
   { uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
   { uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },


### PR DESCRIPTION
Now that Gramine supports secure implementation of eventfd (albeit restricted to single-process applications), MongoDB and Node.js do not require to have an old insecure implementation of eventfd.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/91)
<!-- Reviewable:end -->
