### PR TITLE
Increase MongoDB enclave size to 8GB

### DIFF
--- a/mongodb/mongod.manifest.template
+++ b/mongodb/mongod.manifest.template
@@ -16,7 +16,7 @@ fs.mounts = [
 ]
 
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.enclave_size = "4G"
+sgx.enclave_size = "8G"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '64' }}
 
 sgx.trusted_files = [


### PR DESCRIPTION
4GB enclave size is insufficient for the mongodb workload

Fixes #93. See it for context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/94)
<!-- Reviewable:end -->
