### PR TITLE
[Docs] Remove highlight directive from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,6 @@ Example applications for Gramine
 .. |nbsp| unicode:: 0xa0
    :trim:
 
-.. highlight:: sh
-
-
 This repository contains a curated set of Gramine examples. These examples are
 tested only against the most recent Gramine release (i.e., these examples are
 not guaranteed to work with older releases and unreleased versions of Gramine,


### PR DESCRIPTION
This works around GitHub rendering bug that renders "sh" in this place.

Similar to https://github.com/gramineproject/gramine/pull/1854.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/98)
<!-- Reviewable:end -->
