### PR TITLE
Hide `loader.entrypoint` manifest option

### DIFF
--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -3,7 +3,6 @@
 
 # Curl manifest file example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ curl_dir }}/curl"
 
 loader.log_level = "{{ log_level }}"
@@ -30,7 +29,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ curl_dir }}/curl",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -4,7 +4,6 @@
 # This is a general manifest template for running GCC and its utility programs,
 # including as, cc1, collect2, ld.
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/usr/bin/gcc"
 
 loader.log_level = "{{ log_level }}"
@@ -33,7 +32,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:/usr/bin/gcc",
   "file:/usr/bin/as",
   "file:/usr/bin/ld",

--- a/iperf/iperf3.manifest.template
+++ b/iperf/iperf3.manifest.template
@@ -3,7 +3,6 @@
 
 # iperf3 manifest file example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "/install/iperf3"
 
 loader.log_level = "{{ log_level }}"
@@ -43,5 +42,4 @@ sgx.trusted_files = [
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
-  "file:{{ gramine.libos }}",
 ]

--- a/mongodb/mongod.manifest.template
+++ b/mongodb/mongod.manifest.template
@@ -1,7 +1,6 @@
 # Copyright (C) 2024 Gramine contributors
 # SPDX-License-Identifier: BSD-3-Clause
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ execdir }}/mongod"
 
 loader.log_level = "{{ log_level }}"
@@ -23,7 +22,6 @@ sgx.enclave_size = "8G"
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '64' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ execdir }}/mongod",
   "file:{{ gramine.runtimedir() }}/",
   "file:/usr/{{ arch_libdir }}/",

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -3,7 +3,6 @@
 
 # Node.js manifest file example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ nodejs_dir }}/nodejs"
 
 loader.log_level = "{{ log_level }}"
@@ -34,7 +33,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ nodejs_dir }}/nodejs",
 {%- if nodejs_usr_share_dir %}
   "file:{{ nodejs_usr_share_dir }}/",

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -1,7 +1,6 @@
 # Copyright (C) 2024 Gramine contributors
 # SPDX-License-Identifier: BSD-3-Clause
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.log_level = "{{ log_level }}"
@@ -28,7 +27,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.use_exinfo = true
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ entrypoint }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/openvino/benchmark_app.manifest.template
+++ b/openvino/benchmark_app.manifest.template
@@ -1,7 +1,6 @@
 # Copyright (C) 2024 Gramine contributors
 # SPDX-License-Identifier: BSD-3-Clause
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "benchmark_app"
 
 loader.log_level = "{{ log_level }}"
@@ -28,7 +27,6 @@ libos.check_invalid_pointers = false
 
 sgx.trusted_files = [
   "file:benchmark_app",
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -3,7 +3,6 @@
 
 # PyTorch manifest template
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.log_level = "{{ log_level }}"
@@ -40,7 +39,6 @@ sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ entrypoint }}",
-  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:/usr/lib/",
   "file:{{ arch_libdir }}/",

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -3,7 +3,6 @@
 
 # R manifest example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ r_exec }}"
 
 loader.log_level = "{{ log_level }}"
@@ -41,7 +40,6 @@ sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 sgx.use_exinfo = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ r_exec }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/scikit-learn-intelex/sklearnex.manifest.template
+++ b/scikit-learn-intelex/sklearnex.manifest.template
@@ -3,7 +3,6 @@
 
 # Intel(R) Extension for Scikit-learn* manifest example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ entrypoint }}"
 
 loader.log_level = "{{ log_level }}"
@@ -48,7 +47,6 @@ sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '128' }}
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ entrypoint }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -3,7 +3,6 @@
 
 # TensorFlow Lite example
 
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "label_image"
 
 loader.log_level = "{{ log_level }}"
@@ -24,7 +23,6 @@ sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '16' }}
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:label_image",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",


### PR DESCRIPTION
For end users, the `loader.entrypoint` manifest option is always the LibOS binary. Similarly, `sgx.trusted_files` must always contain the LibOS binary.

This commit is a counterpart to the [commit "[Python,CI-Examples] Hide loader.entrypoint manifest option"](https://github.com/gramineproject/gramine/pull/1716) in the core Gramine repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/99)
<!-- Reviewable:end -->
