### PR TITLE
Modify Makefiles to prepare all files before generating manifest

### DIFF
--- a/iperf/Makefile
+++ b/iperf/Makefile
@@ -26,23 +26,31 @@ $(IPERF_DIR)/configure:
 	mkdir $(IPERF_DIR)
 	tar -C $(IPERF_DIR) --strip-components=1 -xf $(IPERF_SRC)
 
-$(IPERF_DIR)/src/.libs/iperf3: $(IPERF_DIR)/configure
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
+$(IPERF_DIR)/src/.libs/iperf3 $(IPERF_DIR)/src/.libs/libiperf.so.0: iperf_build
+	@:
+
+.INTERMEDIATE: iperf_build
+iperf_build: $(IPERF_DIR)/configure
 	cd $(IPERF_DIR) && ./configure
 	$(MAKE) -C $(IPERF_DIR)
 
-iperf3.manifest: iperf3.manifest.template
+iperf3.manifest: iperf3.manifest.template install/iperf3 install/libiperf.so.0
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		$< > $@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
 iperf3.sig iperf3.manifest.sgx: sgx_sign
 	@:
 
 .INTERMEDIATE: sgx_sign
-sgx_sign: iperf3.manifest $(IPERF_DIR)/src/.libs/iperf3
+sgx_sign: iperf3.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/mongodb/Makefile
+++ b/mongodb/Makefile
@@ -22,7 +22,9 @@ mongod.manifest: mongod.manifest.template
 		-Dexecdir=$(shell dirname $(shell which mongod)) \
 		$< $@
 
-# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`)
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
 mongod.sig mongod.manifest.sgx: sgx_sign
 	@:
 

--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -18,7 +18,7 @@ ifeq ($(SGX),1)
 all: nodejs.manifest.sgx nodejs.sig
 endif
 
-nodejs.manifest: nodejs.manifest.template
+nodejs.manifest: nodejs.manifest.template helloworld.js
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
@@ -33,7 +33,7 @@ nodejs.manifest.sgx nodejs.sig: sgx_sign
 	@:
 
 .INTERMEDIATE: sgx_sign
-sgx_sign: nodejs.manifest helloworld.js
+sgx_sign: nodejs.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/openvino/Makefile
+++ b/openvino/Makefile
@@ -76,7 +76,7 @@ $(VENV_DIR)/.INSTALLATION_OK:
 	&& deactivate \
 	&& touch $@
 
-benchmark_app.manifest: benchmark_app.manifest.template
+benchmark_app.manifest: benchmark_app.manifest.template | benchmark_app
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
@@ -91,7 +91,7 @@ benchmark_app.manifest.sgx benchmark_app.sig: sgx_sign
 	@:
 
 .INTERMEDIATE: sgx_sign
-sgx_sign: benchmark_app.manifest | benchmark_app
+sgx_sign: benchmark_app.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx

--- a/scikit-learn-intelex/Makefile
+++ b/scikit-learn-intelex/Makefile
@@ -25,7 +25,8 @@ sklearnex.manifest: sklearnex.manifest.template
 		$< >$@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
-# see the helloworld example for details on this workaround.
+# for details on this workaround see
+# https://github.com/gramineproject/gramine/blob/e8735ea06c/CI-Examples/helloworld/Makefile
 sklearnex.manifest.sgx sklearnex.sig: sgx_sign
 	@:
 

--- a/tensorflow-lite/Makefile
+++ b/tensorflow-lite/Makefile
@@ -72,7 +72,7 @@ label_image.manifest.sgx label_image.sig: sgx_sign
 	@:
 
 .INTERMEDIATE: sgx_sign
-sgx_sign: label_image.manifest inception_v3.tflite labels.txt
+sgx_sign: label_image.manifest
 	gramine-sgx-sign \
 		--manifest $< \
 		--output $<.sgx


### PR DESCRIPTION
Commit "[LibOS] Move trusted and allowed files logic to LibOS" (currently as PR https://github.com/gramineproject/gramine/pull/1812) in core Gramine repository requires that the generation of the `.manifest` file happens after all executable/test/script files are prepared on the system. This commit adjusts the build system (Makefiles) in this way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/105)
<!-- Reviewable:end -->
