### PR TITLE
Add note on increasing `vm.max_map_count` for `kmeans_perf_eval.py`

### DIFF
--- a/scikit-learn-intelex/README.md
+++ b/scikit-learn-intelex/README.md
@@ -56,6 +56,15 @@ gramine-direct ./sklearnex scripts/kmeans_example.py
 gramine-direct ./sklearnex scripts/kmeans_perf_eval.py
 ```
 
+**NOTE**: `kmeans_perf_eval.py` can exceed the process's maximum number of
+mappings in Linux. You may need to increase the value in
+`/proc/sys/vm/max_map_count`:
+
+```
+# the value is just an example
+sudo sysctl vm.max_map_count=1310720
+```
+
 With SGX:
 
 ```sh


### PR DESCRIPTION
Linux can return `-ENOMEM` if a request to `mmap()` exceeds the process's maximum number of mappings. This may happen for the `kmeans_perf_eval.py` Scikit-learn example during the checkpoint/restore on the Linux PAL after commit c0a2765
"[LibOS,PAL/Linux-SGX] Add EDMM lazy allocation support". Therefore, `vm.max_map_count` needs to be set to a larger value in such case.

Fixes https://github.com/gramineproject/examples/issues/107.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/108)
<!-- Reviewable:end -->
