### PR TITLE
Update PyTorch example for Ubuntu 24.04

### DIFF
--- a/pytorch/Makefile
+++ b/pytorch/Makefile
@@ -3,6 +3,12 @@
 
 # PyTorch and the pre-trained model must be installed on the system. See README for details.
 
+SHELL := /bin/bash
+
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+VENV_DIR ?= $(THIS_DIR)/my_venv
+ENTRYPOINT := $(VENV_DIR)/bin/python3
+
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)
@@ -21,7 +27,8 @@ pytorch.manifest: pytorch.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
-		-Dentrypoint=$(realpath $(shell sh -c "command -v python3")) \
+		-Dentrypoint=$(ENTRYPOINT) \
+		-Dvenv_dir=$(VENV_DIR) \
 		$< > $@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -16,16 +16,15 @@ With high probability (41%) the classifier detected the image to contain a
 Labrador retriever.
 
 # Pre-requisites
-
-The following steps should suffice to run the workload on a stock Ubuntu 18.04
-installation.
+The following steps should suffice to run the workload on a standard Ubuntu distribution.
 
 - `sudo apt install libnss-mdns libnss-myhostname` to install additional
   DNS-resolver libraries.
 - `sudo apt install python3-pip lsb-release` to install `pip` and `lsb_release`.
   The former is required to install additional Python packages while the latter
   is used by the Makefile.
-- `pip3 install --user torchvision pillow` to install the torchvision and pillow
+- `python3 -m venv my_venv && source my_venv/bin/activate` to create and activate a virtual environment.
+- `pip3 install torchvision pillow` to install the torchvision and pillow
   Python packages and their dependencies (usually in $HOME/.local). WARNING:
   This downloads several hundred megabytes of data!
 - `python3 download-pretrained-model.py` to download and save the pre-trained

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -22,6 +22,7 @@ fs.mounts = [
   { path = "/usr/lib", uri = "file:/usr/lib" },
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr/{{ arch_libdir }}", uri = "file:/usr/{{ arch_libdir }}" },
+  { path = "{{ venv_dir }}", uri = "file:{{ venv_dir }}" },
 {% for path in python.get_sys_path(entrypoint) %}
   { path = "{{ path }}", uri = "file:{{ path }}" },
 {% endfor %}
@@ -43,6 +44,7 @@ sgx.trusted_files = [
   "file:/usr/lib/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
+  "file:{{ venv_dir }}/",
 {% for path in python.get_sys_path(entrypoint) %}
   "file:{{ path }}{{ '/' if path.is_dir() else '' }}",
 {% endfor %}


### PR DESCRIPTION
## Description of Changes

This pull request adds support for running the PyTorch PPML workload on **Ubuntu 24.04**. A virtual environment is required for installing `torchvision` and `pillow`.

### Key Changes:
- **README.md**: Updated to include installation steps for Ubuntu 24.04.
- **pytorch.manifest.template**: Added `venv_dir` in `fs.mount`.
- **sgx.trusted**: Included `venv_dir` in the trusted files list.

### Build Instructions
- Run `make` for the non-SGX version.
- Run `make SGX=1` for the SGX version.

### Run Instructions
Execute one of the following commands to run the workload:
- **Natively**: `python3 pytorchexample.py`
- **Gramine without SGX**: `gramine-direct ./pytorch ./pytorchexample.py`
- **Gramine with SGX**: `gramine-sgx ./pytorch ./pytorchexample.py`

Refer to the End-To-End Confidential PyTorch Workflow for more details (DCAP software must be installed).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/109)
<!-- Reviewable:end -->
