### PR TITLE
Use abspath for venv and entrypoint

### DIFF
--- a/pytorch/Makefile
+++ b/pytorch/Makefile
@@ -27,8 +27,8 @@ pytorch.manifest: pytorch.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
-		-Dentrypoint=$(ENTRYPOINT) \
-		-Dvenv_dir=$(VENV_DIR) \
+		-Dentrypoint=$(abspath $(ENTRYPOINT)) \
+		-Dvenv_dir=$(abspath $(VENV_DIR)) \
 		$< > $@
 
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),


### PR DESCRIPTION
### Description

This pull request addresses the issue where the PyTorch example fails due to the use of relative mount paths. The error message indicated that relative paths like `".//my_venv/bin/python3"` are disallowed and should be converted to absolute paths.

### Changes Made

- Updated the `Makefile` to use absolute paths for the `entrypoint` and `venv_dir` variables.
- Used the `abspath` function to convert relative paths to absolute paths.

### Steps to Reproduce

1. Create a virtual environment:
   ```sh
   python3 -m venv my_venv
   source my_venv/bin/activate
   ```
2. Install the required packages:
   ```sh
   pip3 install torchvision pillow
   ```
3. Run the PyTorch example:
   ```sh
   python3 download-pretrained-model.py
   make clean && make SGX=1
   ```

### Actual Output

Previously, the example failed with the following error:
```
[P1:T1:] error: Relative mount path: 'fs.mounts[0].path' (".//my_venv/bin/python3") is disallowed! Consider converting it to absolute by adding "/" at the beginning.
[P1:T1:] error: libos_init() failed in init_mount: Invalid argument (EINVAL)
```

### Expected Output

The PyTorch example should run without errors related to relative mount paths.

Fixes #110

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/111)
<!-- Reviewable:end -->
