### PR TITLE
Update pytorch weights_only parameter to False

### DIFF
--- a/pytorch/pytorchexample.py
+++ b/pytorch/pytorchexample.py
@@ -4,8 +4,12 @@
 from torchvision import models
 import torch
 
-# Load the model from a file
-alexnet = torch.load("alexnet-pretrained.pt")
+# Load the model from a file. This file needs to be obtained from a trusted 
+# source, because it can contain code, not only data.
+# Note: For PyTorch 2.6 and later, direct unpickling with weights_only=True 
+# (which was made the default) can fail if the model file contains more than 
+# just the weights and includes classes or functions that are not allowlisted.
+alexnet = torch.load("alexnet-pretrained.pt", weights_only=False)
 
 # Prepare a transform to get the input image into a format (e.g., x,y dimensions) the classifier
 # expects.

--- a/pytorch/pytorchexample.py
+++ b/pytorch/pytorchexample.py
@@ -4,10 +4,10 @@
 from torchvision import models
 import torch
 
-# Load the model from a file. This file needs to be obtained from a trusted 
+# Load the model from a file. This file needs to be obtained from a trusted
 # source, because it can contain code, not only data.
-# Note: For PyTorch 2.6 and later, direct unpickling with weights_only=True 
-# (which was made the default) can fail if the model file contains more than 
+# Note: For PyTorch 2.6 and later, direct unpickling with weights_only=True
+# (which was made the default) can fail if the model file contains more than
 # just the weights and includes classes or functions that are not allowlisted.
 alexnet = torch.load("alexnet-pretrained.pt", weights_only=False)
 


### PR DESCRIPTION
- Updated pytorchexample.py to set the weights_only argument to False when calling torch.load.
- This change resolves the UnpicklingError encountered when loading the pre-trained model.
Fixes #113 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/examples/114)
<!-- Reviewable:end -->
